### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/registry/api/routes/logs.py
+++ b/registry/api/routes/logs.py
@@ -186,7 +186,7 @@ async def websocket_logs(
             is_internal = True
         # Check provider authentication
         elif provider_secret := headers.get("provider-secret"):
-            print(f"Checking provider secret: {provider_secret[:10]}...")  # Debug log
+            print("Checking provider secret...")  # Debug log
             try:
                 provider = provider_service.get_provider_by_secret(provider_secret)
                 if provider:


### PR DESCRIPTION
Potential fix for [https://github.com/authed-dev/authed/security/code-scanning/5](https://github.com/authed-dev/authed/security/code-scanning/5)

To fix the problem, we should avoid logging any part of the `provider-secret`. Instead, we can log a generic message indicating that a provider secret is being checked without including any part of the secret itself. This way, we maintain the necessary logging for debugging purposes without exposing sensitive information.

We need to modify the logging statement on line 189 to remove the sensitive data. Specifically, we will replace `print(f"Checking provider secret: {provider_secret[:10]}...")` with a more generic message like `print("Checking provider secret...")`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
