### PR TITLE
asch/permissions playground

### DIFF
--- a/permissions/parser/interpreter.py
+++ b/permissions/parser/interpreter.py
@@ -379,8 +379,16 @@ class Interpreter(BaseInterpreter):
                 if self.schema_provider and "resource_type" in result:
                     field_type = self.schema_provider.get_field_type(current_condition["field"], result["resource_type"])
                 
+                # Default to STRING if field_type is None
+                if field_type is None:
+                    field_type = DataType.STRING  # Default to string for unknown field types
+                
                 # Coerce the value using our pipeline engine
-                converted_value = self.coercion_engine.coerce(token, field_type)
+                try:
+                    converted_value = self.coercion_engine.coerce(token, field_type)
+                except Exception as e:
+                    # If coercion fails, use the original value
+                    converted_value = token
                 
                 result["conditions"].append({
                     "field": current_condition["field"],

--- a/permissions/parser/interpreter.py
+++ b/permissions/parser/interpreter.py
@@ -161,6 +161,29 @@ class SchemaProvider(BaseSchemaProvider):
                     metadata.update(resource_data["metadata"])
         
         return metadata
+        
+    def get_resource_fields(self, resource_type: ResourceType) -> Dict[str, Dict[str, Any]]:
+        """
+        Get all fields available for a specific resource type.
+        
+        Args:
+            resource_type: The resource type
+            
+        Returns:
+            Dict[str, Dict[str, Any]]: Dictionary of field definitions
+        """
+        fields = {}
+        
+        # Collect fields from all integrations that define this resource type
+        for integration_name, integration_data in self.integration_mappings.items():
+            if resource_type.value in integration_data:
+                resource_data = integration_data[resource_type.value]
+                # Add all fields except special entries that start with underscore
+                for field_name, field_data in resource_data.items():
+                    if not field_name.startswith('_'):
+                        fields[field_name] = field_data
+        
+        return fields
 
 class Interpreter(BaseInterpreter):
     """Simple implementation of the BaseInterpreter."""
@@ -285,13 +308,34 @@ class Interpreter(BaseInterpreter):
                         raise ValueError(f"Expected a structural helper (WITH, NAMED, etc.) or end of statement, got {token}")
             
             elif state == "CONDITION_FIELD":
-                # Field name for the condition
-                current_condition["field"] = self._map_field_from_helper(current_condition["helper"], token)
-                state = "CONDITION_OPERATOR"
+                # If the token is an operator or equals sign, it means we're using the default field for this helper
+                if token == "=" or token in [op.value for op in ConditionOperator]:
+                    # Get the default field for this helper from the mappings
+                    if self.schema_provider and "helper" in current_condition:
+                        field = self.schema_provider.map_field(current_condition["helper"], "")
+                        current_condition["field"] = field or current_condition["helper"].value.lower()
+                    else:
+                        current_condition["field"] = current_condition["helper"].value.lower()
+                    
+                    # Immediately process this token as an operator
+                    state = "CONDITION_OPERATOR"
+                    # Don't increment i, reprocess this token as the operator
+                    continue
+                else:
+                    # Normal case - token is a field name
+                    current_condition["field"] = self._map_field_from_helper(current_condition["helper"], token)
+                    state = "CONDITION_OPERATOR"
             
             elif state == "CONDITION_OPERATOR":
                 # Operator for the condition
                 try:
+                    # Handle the equals sign as IS operator
+                    if token == "=":
+                        current_condition["operator"] = ConditionOperator.IS
+                        state = "CONDITION_VALUE"
+                        i += 1
+                        continue
+                    
                     # Check for compound operators like "IS NOT", "GREATER THAN", etc.
                     # Simple 2-token operators
                     compound_operators = {

--- a/permissions/parser/tokenizer.py
+++ b/permissions/parser/tokenizer.py
@@ -210,7 +210,15 @@ class Tokenizer(BaseTokenizer):
             # Try to match condition operators (IS, CONTAINS, etc.)
             operator_match = re.match(f'^({self.patterns["condition_operator"]})', remaining, re.IGNORECASE)
             if operator_match:
-                tokens.append(operator_match.group(1).upper())
+                operator_token = operator_match.group(1).upper()
+                
+                # If the previous token was also an operator, log a warning
+                # This typically happens when someone types something like "= CONTAINS", which is invalid
+                if tokens and tokens[-1] in self.patterns["condition_operator"].split("|") + ["="]:
+                    logger.warning(f"Ignoring duplicate operator: {operator_token} after {tokens[-1]}")
+                else:
+                    tokens.append(operator_token)
+                    
                 remaining = remaining[operator_match.end():]
                 matched = True
                 continue

--- a/permissions/playground/__init__.py
+++ b/permissions/playground/__init__.py
@@ -1,0 +1,9 @@
+"""Playground module for testing and experimenting with the permissions system."""
+
+from .session import PlaygroundSession
+from .cli import start_cli
+
+__all__ = [
+    "PlaygroundSession",
+    "start_cli"
+] 

--- a/permissions/playground/cli.py
+++ b/permissions/playground/cli.py
@@ -5,8 +5,8 @@ import cmd
 import json
 import argparse
 
-from .session import PlaygroundSession
-from .completions import Completer
+from permissions.playground.session import PlaygroundSession
+from permissions.playground.completions import Completer
 
 
 class PermissionShell(cmd.Cmd):

--- a/permissions/playground/cli.py
+++ b/permissions/playground/cli.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Interactive CLI for testing permission statements."""
+
+import cmd
+import json
+import argparse
+
+from .session import PlaygroundSession
+from .completions import Completer
+
+
+class PermissionShell(cmd.Cmd):
+    """
+    Interactive shell for testing permission statements.
+    
+    This class provides a command-line interface for experimenting
+    with permission statements, seeing how they are tokenized, interpreted,
+    and eventually translated into OPA inputs.
+    """
+    
+    intro = """
+Permission Statement Playground
+==============================
+Type permission statements to see how they are processed.
+Type :help or ? to see available commands.
+Type :exit or Ctrl-D to exit.
+"""
+    prompt = '> '
+    
+    def __init__(self):
+        """Initialize the shell with a playground session."""
+        super().__init__()
+        self.session = PlaygroundSession()
+        self.completer = Completer()
+        
+        # Register built-in commands
+        self.commands = {
+            "help": self.do_help,
+            "exit": self.do_exit,
+            "quit": self.do_exit,
+            "fields": self.do_fields,
+            "examples": self.do_examples,
+            "tokens": self.do_tokens,
+            "interpret": self.do_interpret,
+            "statement": self.do_statement,
+            "opa_input": self.do_opa_input,
+        }
+    
+    def default(self, line: str) -> bool:
+        """
+        Default behavior for non-command input - process as a permission statement.
+        
+        Args:
+            line: The input line
+            
+        Returns:
+            bool: False to continue the shell, True to exit
+        """
+        # Check if this is a command (starts with : or .)
+        if line.startswith(':'):
+            cmd_name = line[1:].split()[0]
+            args = line[1:].split()[1:] if len(line[1:].split()) > 1 else []
+            
+            if cmd_name in self.commands:
+                return self.commands[cmd_name](' '.join(args))
+            else:
+                print(f"Unknown command: {cmd_name}")
+                return False
+        
+        # Process as a permission statement
+        result = self.session.process_statement(line)
+        
+        if result.error:
+            print(f"Error: {result.error}")
+            return False
+        
+        # Display tokenization result
+        if result.tokenization:
+            print("\nTokens:")
+            print(result.tokenization.tokens)
+        
+        # Display statement result
+        if result.statement:
+            print("\nStructured Statement:")
+            statement = result.statement.statement
+            print(f"Command: {statement.command.value}")
+            print(f"Access Types: {[access.value for access in statement.access_types]}")
+            print(f"Resource Type: {statement.resource_type.value}")
+            
+            if statement.conditions:
+                print("\nConditions:")
+                for condition in statement.conditions:
+                    print(f"  {condition.field} {condition.operator.value} {condition.value}")
+            
+            # Display OPA input
+            if result.opa_input:
+                print("\nOPA Input:")
+                print(json.dumps(result.opa_input.input, indent=2))
+        
+        return False
+    
+    def do_exit(self, arg: str) -> bool:
+        """
+        Exit the shell.
+        
+        Args:
+            arg: Command arguments (ignored)
+            
+        Returns:
+            bool: True to exit
+        """
+        print("Exiting...")
+        return True
+    
+    def do_help(self, arg: str) -> bool:
+        """
+        Display help information.
+        
+        Args:
+            arg: Optional specific command name
+            
+        Returns:
+            bool: False to continue
+        """
+        if arg:
+            # Help for a specific command
+            if arg in self.commands:
+                print(self.commands[arg].__doc__ or "No help available.")
+            else:
+                print(f"Unknown command: {arg}")
+        else:
+            # General help
+            print("""
+Available commands:
+  :help          Show this help message
+  :exit          Exit the shell
+  :fields TYPE   Show available fields for a resource type (e.g., :fields ISSUES)
+  :examples      Show example permission statements
+  :tokens        Show the tokens from the last processed statement
+  :interpret     Show the interpreted data from the last processed statement
+  :statement     Show the structured permission statement from the last processed statement
+  :opa_input     Show the OPA input from the last processed statement
+
+You can also type permission statements directly:
+  GIVE READ ACCESS TO ISSUES TAGGED = urgent
+  DENY WRITE ACCESS TO ISSUES ASSIGNED TO antoni
+""")
+        return False
+    
+    def do_fields(self, arg: str) -> bool:
+        """
+        Show available fields for a resource type.
+        
+        Args:
+            arg: The resource type (e.g., "ISSUES")
+            
+        Returns:
+            bool: False to continue
+        """
+        if not arg:
+            print("Usage: :fields RESOURCE_TYPE")
+            print("Available resource types:", ", ".join(self.completer.resource_types))
+            return False
+        
+        fields = self.session.get_resource_fields(arg)
+        if not fields:
+            print(f"No fields found for resource type: {arg}")
+            return False
+        
+        print(f"\nFields for {arg}:")
+        for field_name, field_info in fields.items():
+            # Skip metadata
+            if field_name == "metadata":
+                continue
+            
+            # Print field info with data type
+            data_type = field_info.get("data_type", "unknown")
+            description = field_info.get("description", "")
+            print(f"  {field_name} ({data_type}): {description}")
+        
+        return False
+    
+    def do_examples(self, arg: str) -> bool:
+        """
+        Show example permission statements.
+        
+        Args:
+            arg: Ignored
+            
+        Returns:
+            bool: False to continue
+        """
+        examples = self.session.get_example_statements()
+        
+        print("\nExample permission statements:")
+        for example in examples:
+            print(f"  {example}")
+        
+        return False
+    
+    def do_tokens(self, arg: str) -> bool:
+        """
+        Show the tokens from the last processed statement.
+        
+        Args:
+            arg: Ignored
+            
+        Returns:
+            bool: False to continue
+        """
+        if not self.session.last_result or not self.session.last_result.tokenization:
+            print("No tokens available. Process a statement first.")
+            return False
+        
+        print("\nTokens:")
+        print(self.session.last_result.tokenization.tokens)
+        return False
+    
+    def do_interpret(self, arg: str) -> bool:
+        """
+        Show the interpreted data from the last processed statement.
+        
+        Args:
+            arg: Ignored
+            
+        Returns:
+            bool: False to continue
+        """
+        if not self.session.last_result or not self.session.last_result.interpretation:
+            print("No interpreted data available. Process a statement first.")
+            return False
+        
+        print("\nInterpreted Data:")
+        print(json.dumps(self.session.last_result.interpretation.parsed_data, indent=2))
+        return False
+    
+    def do_statement(self, arg: str) -> bool:
+        """
+        Show the structured permission statement from the last processed statement.
+        
+        Args:
+            arg: Ignored
+            
+        Returns:
+            bool: False to continue
+        """
+        if not self.session.last_result or not self.session.last_result.statement:
+            print("No statement available. Process a statement first.")
+            return False
+        
+        print("\nStructured Statement:")
+        print(json.dumps(self.session.last_result.statement.json_representation, indent=2))
+        return False
+    
+    def do_opa_input(self, arg: str) -> bool:
+        """
+        Show the OPA input from the last processed statement.
+        
+        Args:
+            arg: Ignored
+            
+        Returns:
+            bool: False to continue
+        """
+        if not self.session.last_result or not self.session.last_result.opa_input:
+            print("No OPA input available. Process a statement first.")
+            return False
+        
+        print("\nOPA Input:")
+        print(json.dumps(self.session.last_result.opa_input.input, indent=2))
+        return False
+    
+    def emptyline(self) -> bool:
+        """
+        Handle empty line input.
+        
+        Returns:
+            bool: False to continue
+        """
+        return False
+    
+    def do_EOF(self, arg: str) -> bool:
+        """
+        Handle Ctrl-D.
+        
+        Returns:
+            bool: True to exit
+        """
+        print("\nExiting...")
+        return True
+
+
+def parse_args():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description='Interactive CLI for testing permission statements.')
+    return parser.parse_args()
+
+
+def start_cli():
+    """Start the interactive CLI."""
+    args = parse_args()
+    shell = PermissionShell()
+    shell.cmdloop()
+
+
+if __name__ == '__main__':
+    start_cli() 

--- a/permissions/playground/completions.py
+++ b/permissions/playground/completions.py
@@ -3,7 +3,7 @@
 from typing import List, Dict, Set
 import re
 
-from ..models import (
+from permissions.models import (
     BaseCommand, 
     AccessType, 
     ResourceType, 
@@ -11,7 +11,7 @@ from ..models import (
     StructuralHelper,
     DataType
 )
-from ..integrations.linear import LINEAR_RESOURCES
+from permissions.integrations.linear import LINEAR_RESOURCES
 
 
 class Completer:

--- a/permissions/playground/completions.py
+++ b/permissions/playground/completions.py
@@ -1,0 +1,159 @@
+"""Context-aware completions for permission statements."""
+
+from typing import List, Dict, Set
+import re
+
+from ..models import (
+    BaseCommand, 
+    AccessType, 
+    ResourceType, 
+    ConditionOperator,
+    StructuralHelper,
+    DataType
+)
+from ..integrations.linear import LINEAR_RESOURCES
+
+
+class Completer:
+    """
+    Context-aware completer for permission statements.
+    
+    This class provides completion suggestions based on the current
+    token position and the tokens parsed so far.
+    """
+    
+    def __init__(self):
+        """Initialize the completer with known command components."""
+        self.base_commands = [cmd.value for cmd in BaseCommand]
+        self.access_types = [access.value for access in AccessType]
+        self.resource_types = [resource.value for resource in ResourceType]
+        self.condition_operators = [op.value for op in ConditionOperator]
+        self.structural_helpers = [
+            StructuralHelper.get_display_value(helper) for helper in StructuralHelper
+        ]
+        
+        # Linear-specific resources
+        self.linear_resources = LINEAR_RESOURCES
+        
+        # Extract field names from Linear resources
+        self.resource_fields: Dict[str, Set[str]] = {}
+        for resource_type, fields in LINEAR_RESOURCES.items():
+            if resource_type.startswith("_"):  # Skip helper mappings
+                continue
+            self.resource_fields[resource_type] = set(fields.keys())
+    
+    def complete(self, text: str, current_position: int) -> List[str]:
+        """
+        Get completion suggestions based on the current text and cursor position.
+        
+        Args:
+            text: The current input text
+            current_position: The current cursor position
+            
+        Returns:
+            List[str]: List of completion suggestions
+        """
+        # Get the text up to the cursor position
+        text_to_cursor = text[:current_position]
+        
+        # Tokenize the text
+        tokens = self._tokenize(text_to_cursor)
+        
+        # Determine the context for suggestions
+        return self._get_suggestions(tokens)
+    
+    def _tokenize(self, text: str) -> List[str]:
+        """
+        Simple tokenizer for completion purposes.
+        
+        Args:
+            text: The text to tokenize
+            
+        Returns:
+            List[str]: List of tokens
+        """
+        # This is a simplified tokenizer for completion purposes
+        # It's not meant to be as robust as the real tokenizer
+        tokens = []
+        
+        # Split on spaces, keeping quoted strings together
+        pattern = r'(?:[^\s"]+|"[^"]*"?)+'
+        matches = re.findall(pattern, text)
+        
+        for match in matches:
+            # Remove quotes from quoted strings
+            if match.startswith('"') and match.endswith('"'):
+                match = match[1:-1]
+            tokens.append(match)
+        
+        return tokens
+    
+    def _get_suggestions(self, tokens: List[str]) -> List[str]:
+        """
+        Get completion suggestions based on the tokens parsed so far.
+        
+        Args:
+            tokens: The tokens parsed so far
+            
+        Returns:
+            List[str]: List of completion suggestions
+        """
+        # Empty statement - suggest base commands
+        if not tokens:
+            return self.base_commands
+        
+        # Start of statement
+        if len(tokens) == 1 and tokens[0] in self.base_commands:
+            return self.access_types
+        
+        # After "GIVE READ" or similar
+        if len(tokens) == 2 and tokens[0] in self.base_commands and tokens[1] in self.access_types:
+            return ["ACCESS TO"]
+        
+        # After "GIVE READ ACCESS TO" - suggest resource types
+        if len(tokens) >= 3 and tokens[-2] == "ACCESS" and tokens[-1] == "TO":
+            return self.resource_types
+        
+        # After resource type - suggest structural helpers
+        if len(tokens) >= 4 and tokens[-2] == "TO" and tokens[-1] in self.resource_types:
+            return self.structural_helpers
+        
+        # After structural helper - suggest condition operators
+        if len(tokens) >= 5 and tokens[-1] in self.structural_helpers:
+            return self.condition_operators
+        
+        # After condition operator - suggest field values
+        if len(tokens) >= 6 and tokens[-1] in self.condition_operators:
+            # Get resource type and field to suggest values
+            resource_idx = tokens.index("TO") + 1 if "TO" in tokens else -1
+            if resource_idx >= 0 and resource_idx < len(tokens):
+                resource_type = tokens[resource_idx]
+                # Get last structural helper
+                struct_helpers = [t for t in tokens if t in self.structural_helpers]
+                if struct_helpers:
+                    last_helper = struct_helpers[-1]
+                    # Check if we have sample values for this field
+                    if last_helper == "TAGGED":
+                        return ["urgent", "bug", "feature", "backlog", "wip"]
+                    elif last_helper == "ASSIGNED TO":
+                        return ["antoni", "john", "jane", "unassigned"]
+                    elif last_helper == "WITH" and tokens[-3] == "STATUS":
+                        return ["Todo", "In Progress", "Done", "Canceled"]
+        
+        # Default to no suggestions
+        return []
+        
+    def get_field_suggestions(self, resource_type: str) -> List[str]:
+        """
+        Get suggestions for fields of a resource type.
+        
+        Args:
+            resource_type: The resource type
+            
+        Returns:
+            List[str]: List of field suggestions
+        """
+        resource_type = resource_type.upper()
+        if resource_type in self.resource_fields:
+            return sorted(list(self.resource_fields[resource_type]))
+        return [] 

--- a/permissions/playground/completions.py
+++ b/permissions/playground/completions.py
@@ -155,4 +155,29 @@ class Completer:
         resource_type = resource_type.upper()
         if resource_type in self.resource_fields:
             return sorted(list(self.resource_fields[resource_type]))
-        return [] 
+        return []
+        
+    def _get_fields_for_resource(self, resource_type: str) -> List[str]:
+        """
+        Get all fields for a resource type.
+        
+        Args:
+            resource_type: The resource type (case insensitive)
+            
+        Returns:
+            List[str]: List of fields for the resource type
+        """
+        resource_type = resource_type.upper()
+        
+        # First check if we have this resource in our fields
+        if resource_type in self.resource_fields:
+            return list(self.resource_fields[resource_type])
+            
+        # If not, use hardcoded defaults for common resource types
+        defaults = {
+            "ISSUES": ["id", "title", "description", "assignee", "labels", "status"],
+            "EMAILS": ["sender", "recipient", "subject", "body", "date", "attachments", "tags"],
+            "TEAMS": ["name", "id", "key", "owner"],
+        }
+        
+        return defaults.get(resource_type, []) 

--- a/permissions/playground/completions.py
+++ b/permissions/playground/completions.py
@@ -8,8 +8,7 @@ from permissions.models import (
     AccessType, 
     ResourceType, 
     ConditionOperator,
-    StructuralHelper,
-    DataType
+    StructuralHelper
 )
 from permissions.integrations.linear import LINEAR_RESOURCES
 

--- a/permissions/playground/run.py
+++ b/permissions/playground/run.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""
+Entry point for running the permissions playground.
+
+Usage:
+    python -m permissions.playground.run
+"""
+
+from permissions.playground.cli import start_cli
+
+if __name__ == "__main__":
+    start_cli() 

--- a/permissions/playground/run.py
+++ b/permissions/playground/run.py
@@ -3,8 +3,14 @@
 Entry point for running the permissions playground.
 
 Usage:
-    python -m permissions.playground.run
+    python permissions/playground/run.py
 """
+
+import sys
+import os
+
+# Add the parent directory to sys.path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from permissions.playground.cli import start_cli
 

--- a/permissions/playground/session.py
+++ b/permissions/playground/session.py
@@ -1,0 +1,187 @@
+"""Playground session for parsing and testing permission statements."""
+
+from typing import Dict, List, Any, Optional
+from pydantic import BaseModel
+
+from ..parser import Tokenizer, Interpreter, StatementBuilder, PermissionParser
+from ..models import PermissionStatement, ResourceType, AccessType, BaseCommand
+from ..parser.interpreter import SchemaProvider
+from ..integrations.linear import LINEAR_RESOURCES
+
+
+class TokenizationResult(BaseModel):
+    """Result of tokenizing a permission statement."""
+    original_text: str
+    tokens: List[str]
+
+
+class InterpretationResult(BaseModel):
+    """Result of interpreting tokenized permission statement."""
+    tokens: List[str]
+    parsed_data: Dict[str, Any]
+
+
+class StatementResult(BaseModel):
+    """Result of building a structured permission statement."""
+    statement: PermissionStatement
+    json_representation: Dict[str, Any]
+
+
+class OpaInputResult(BaseModel):
+    """OPA input representation of a permission statement."""
+    input: Dict[str, Any]
+
+
+class PlaygroundResult(BaseModel):
+    """Full result of parsing a permission statement in the playground."""
+    tokenization: Optional[TokenizationResult] = None
+    interpretation: Optional[InterpretationResult] = None
+    statement: Optional[StatementResult] = None
+    opa_input: Optional[OpaInputResult] = None
+    error: Optional[str] = None
+
+
+class PlaygroundSession:
+    """
+    Session for parsing and testing permission statements.
+    
+    This class manages the state of a playground session, including the current
+    permission statement, tokenization, interpretation, and OPA input generation.
+    """
+    
+    def __init__(self):
+        """Initialize a new playground session."""
+        self.linear_schema = SchemaProvider("linear", LINEAR_RESOURCES)
+        self.tokenizer = Tokenizer()
+        self.interpreter = Interpreter(schema_provider=self.linear_schema)
+        self.statement_builder = StatementBuilder()
+        self.parser = PermissionParser(
+            tokenizer=self.tokenizer,
+            interpreter=self.interpreter,
+            builder=self.statement_builder
+        )
+        
+        self.last_result: Optional[PlaygroundResult] = None
+        self.current_statement: Optional[str] = None
+    
+    def process_statement(self, statement_text: str) -> PlaygroundResult:
+        """
+        Process a permission statement and return the full result.
+        
+        Args:
+            statement_text: The permission statement text to process
+            
+        Returns:
+            PlaygroundResult: The full result of processing the statement
+        """
+        result = PlaygroundResult()
+        self.current_statement = statement_text
+        
+        # Step 1: Tokenize
+        try:
+            tokens = self.tokenizer.tokenize(statement_text)
+            result.tokenization = TokenizationResult(
+                original_text=statement_text,
+                tokens=tokens
+            )
+        except Exception as e:
+            result.error = f"Tokenization error: {str(e)}"
+            self.last_result = result
+            return result
+        
+        # Step 2: Interpret
+        try:
+            parsed_data = self.interpreter.interpret(tokens)
+            result.interpretation = InterpretationResult(
+                tokens=tokens,
+                parsed_data=parsed_data
+            )
+        except Exception as e:
+            result.error = f"Interpretation error: {str(e)}"
+            self.last_result = result
+            return result
+        
+        # Step 3: Build structured statement
+        try:
+            statement = self.statement_builder.build(parsed_data)
+            result.statement = StatementResult(
+                statement=statement,
+                json_representation=statement.dict()
+            )
+        except Exception as e:
+            result.error = f"Statement building error: {str(e)}"
+            self.last_result = result
+            return result
+        
+        # Step 4: Generate OPA input
+        try:
+            opa_input = self._generate_opa_input(statement)
+            result.opa_input = OpaInputResult(input=opa_input)
+        except Exception as e:
+            result.error = f"OPA input generation error: {str(e)}"
+        
+        self.last_result = result
+        return result
+    
+    def _generate_opa_input(self, statement: PermissionStatement) -> Dict[str, Any]:
+        """
+        Generate OPA input from a permission statement.
+        
+        Args:
+            statement: The permission statement
+            
+        Returns:
+            Dict[str, Any]: The OPA input
+        """
+        # Get the first access type (usually there's only one)
+        action = statement.access_types[0] if statement.access_types else AccessType.READ
+        
+        # Build conditions list
+        conditions = []
+        for condition in statement.conditions:
+            conditions.append({
+                "field": condition.field,
+                "operator": condition.operator.value,
+                "value": condition.value
+            })
+        
+        # Create OPA input structure
+        return {
+            "action": action.value,
+            "resource": {
+                "type": statement.resource_type.value,
+                "conditions": conditions
+            }
+        }
+    
+    def get_resource_fields(self, resource_type_str: str) -> Dict[str, Dict[str, Any]]:
+        """
+        Get all available fields for a resource type.
+        
+        Args:
+            resource_type_str: The resource type string (e.g., "ISSUES")
+            
+        Returns:
+            Dict[str, Dict[str, Any]]: Fields and their metadata
+        """
+        try:
+            resource_type = ResourceType(resource_type_str.upper())
+            return LINEAR_RESOURCES.get(resource_type.value, {})
+        except (ValueError, KeyError):
+            # If the resource type is not valid, return empty dict
+            return {}
+    
+    def get_example_statements(self) -> List[str]:
+        """
+        Get example permission statements.
+        
+        Returns:
+            List[str]: Example permission statements
+        """
+        return [
+            "GIVE READ ACCESS TO ISSUES",
+            "GIVE READ ACCESS TO ISSUES TAGGED = urgent",
+            "DENY WRITE ACCESS TO ISSUES ASSIGNED TO antoni",
+            "GIVE READ ACCESS TO TEAMS WITH NAME = Engineering",
+            "GIVE READ & WRITE ACCESS TO ISSUES WITH STATUS = Done",
+        ] 

--- a/permissions/playground/session.py
+++ b/permissions/playground/session.py
@@ -52,7 +52,7 @@ class PlaygroundSession:
     
     def __init__(self):
         """Initialize a new playground session."""
-        self.linear_schema = SchemaProvider("linear", LINEAR_RESOURCES)
+        self.linear_schema = SchemaProvider({"linear": LINEAR_RESOURCES})
         self.tokenizer = Tokenizer()
         self.interpreter = Interpreter(schema_provider=self.linear_schema)
         self.statement_builder = StatementBuilder()

--- a/permissions/playground/session.py
+++ b/permissions/playground/session.py
@@ -1,12 +1,13 @@
 """Playground session for parsing and testing permission statements."""
 
 from typing import Dict, List, Any, Optional
+import json
 from pydantic import BaseModel
 
-from ..parser import Tokenizer, Interpreter, StatementBuilder, PermissionParser
-from ..models import PermissionStatement, ResourceType, AccessType, BaseCommand
-from ..parser.interpreter import SchemaProvider
-from ..integrations.linear import LINEAR_RESOURCES
+from permissions.parser import Tokenizer, Interpreter, StatementBuilder, PermissionParser
+from permissions.models import PermissionStatement, ResourceType, AccessType, BaseCommand
+from permissions.parser.interpreter import SchemaProvider
+from permissions.integrations.linear import LINEAR_RESOURCES
 
 
 class TokenizationResult(BaseModel):


### PR DESCRIPTION
Added a permissions playground CLI for testing and experimenting with permission statements. This interactive tool provides real-time suggestions and feedback when writing and testing permission statements.

- **New Features**
  - Built an interactive CLI with auto-completion for permission statements
  - Added context-aware suggestions that show relevant options as you type
  - Created a playground session that processes statements and shows tokenization, interpretation, and OPA input results
  - Added command system for exploring available fields, examples, and debugging options

- **Refactors**
  - Improved the coercion engine to handle different input types more robustly
  - Enhanced the interpreter to support default fields and simplified operator syntax
  - Updated the tokenizer to better handle duplicate operators